### PR TITLE
feat(i18n): Internationalize various UI components

### DIFF
--- a/packages/frontend/src/components/AppDrawer.vue
+++ b/packages/frontend/src/components/AppDrawer.vue
@@ -33,10 +33,10 @@ const { locale, t } = useI18n();
 
 const lang = ref(locale);
 const langOptions = [
-    { label: "English", value: "en-GB" },
-    { label: "German", value: "de" },
-    { label: "Spanish", value: "es" },
-    { label: "Croatian", value: "hr" },
+    { label: t("AppDrawer.languages.english"), value: "en-GB" },
+    { label: t("AppDrawer.languages.german"), value: "de" },
+    { label: t("AppDrawer.languages.spanish"), value: "es" },
+    { label: t("AppDrawer.languages.croatian"), value: "hr" },
 ];
 
 const inventoryLink = computed(function () {
@@ -304,7 +304,7 @@ function setDarkMode(newValue: boolean): void {
 
             <q-separator spaced />
 
-            <q-item clickable @click="onLogoutUser" aria-label="Logout">
+            <q-item clickable @click="onLogoutUser" :aria-label="t('AppDrawer.logoutAriaLabel')">
                 <q-item-section avatar>
                     <q-icon name="fa fa-sign-out" />
                 </q-item-section>

--- a/packages/frontend/src/components/AppTopMenu.vue
+++ b/packages/frontend/src/components/AppTopMenu.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { refreshApp } from "src/helpers/utils";
+import { useI18n } from "vue-i18n";
 
+const { t } = useI18n();
 const emit = defineEmits<(e: "toggle-drawer") => void>();
 const menuLinks = [
     {
@@ -33,7 +35,7 @@ const menuLinks = [
                 :icon="menu.icon"
             />
             <q-space />
-            <q-btn flat aria-label="Menu" @click="emit('toggle-drawer')">
+            <q-btn flat :aria-label="t('AppTopMenu.menuAriaLabel')" @click="emit('toggle-drawer')">
                 <q-icon size="2rem" name="fa fa-bars" />
             </q-btn>
         </q-tabs>

--- a/packages/frontend/src/components/Event/EventGuestSearch.vue
+++ b/packages/frontend/src/components/Event/EventGuestSearch.vue
@@ -34,7 +34,7 @@ function createTableLabel(reservation: PlannedReservation): string {
     const label = `${reservation.guestName} (${reservation.tableLabel})`;
     if (props.showFloorNameInOption) {
         const floorName = props.floors.find(matchesProperty("id", reservation.floorId));
-        return `${label} on ${floorName?.name}`;
+        return `${label} ${t('EventGuestSearch.onFloorConnector')} ${floorName?.name}`;
     }
     return label;
 }
@@ -151,7 +151,7 @@ function setModel(val: string): void {
             <template #before-options>
                 <q-item>
                     <q-item-section>
-                        <q-checkbox v-model="hideArrived" label="Hide arrived" dense @click.stop />
+                        <q-checkbox v-model="hideArrived" :label="t('EventGuestSearch.hideArrivedLabel')" dense @click.stop />
                     </q-item-section>
                 </q-item>
             </template>
@@ -168,7 +168,7 @@ function setModel(val: string): void {
                         <q-icon
                             name="check"
                             color="green"
-                            aria-label="Guest arrived checkmark icon"
+                            :aria-label="t('EventGuestSearch.guestArrivedIconAriaLabel')"
                         />
                     </q-item-section>
                     <q-item-section v-if="scope.opt.isVip" side>
@@ -179,7 +179,7 @@ function setModel(val: string): void {
 
             <template #no-option>
                 <q-item>
-                    <q-item-section class="text-grey"> No results </q-item-section>
+                    <q-item-section class="text-grey"> {{ t('EventGuestSearch.noResultsText') }} </q-item-section>
                 </q-item>
             </template>
         </q-select>

--- a/packages/frontend/src/components/FTBottomDialog.vue
+++ b/packages/frontend/src/components/FTBottomDialog.vue
@@ -4,7 +4,7 @@
             <div class="row justify-center q-mb-md">
                 <button
                     class="dialog-pill cursor-pointer"
-                    aria-label="Close bottom dialog"
+                    :aria-label="t('FTBottomDialog.closeBottomDialogAriaLabel')"
                     @click="onDialogHide"
                 />
             </div>
@@ -18,6 +18,7 @@
 import type { ComponentPublicInstance } from "vue";
 
 import { useDialogPluginComponent } from "quasar";
+import { useI18n } from "vue-i18n";
 
 interface Props {
     component: ComponentPublicInstance;
@@ -27,6 +28,7 @@ interface Props {
 
 const { component, componentPropsObject, listeners } = defineProps<Props>();
 const { dialogRef, onDialogHide } = useDialogPluginComponent();
+const { t } = useI18n();
 
 defineEmits(useDialogPluginComponent.emits);
 </script>

--- a/packages/frontend/src/components/FTDialog.vue
+++ b/packages/frontend/src/components/FTDialog.vue
@@ -13,7 +13,7 @@
                         flat
                         icon="fa fa-close"
                         @click="onDialogHide"
-                        aria-label="Close dialog"
+                        :aria-label="t('FTDialog.closeDialogAriaLabel')"
                     />
                 </template>
                 <h6 class="text-h6 q-ma-none q-ml-sm" v-if="title">{{ title }}</h6>
@@ -31,6 +31,7 @@ import type { ComponentPublicInstance } from "vue";
 
 import { useDialogPluginComponent } from "quasar";
 import { isMobile } from "src/global-reactives/screen-detection";
+import { useI18n } from "vue-i18n";
 
 interface Props {
     component: ComponentPublicInstance;
@@ -48,6 +49,7 @@ const {
     title = "",
 } = defineProps<Props>();
 const { dialogRef, onDialogHide } = useDialogPluginComponent();
+const { t } = useI18n();
 
 defineEmits(useDialogPluginComponent.emits);
 </script>

--- a/packages/frontend/src/components/FTTimeframeSelector.vue
+++ b/packages/frontend/src/components/FTTimeframeSelector.vue
@@ -38,7 +38,7 @@
                 </span>
                 <span v-else>
                     <span v-if="dateRange && dateRange.from && dateRange.to">
-                        {{ formatDateDisplay(dateRange.from) }} to
+                        {{ formatDateDisplay(dateRange.from) }} {{ t('FTTimeframeSelector.to') }}
                         {{ formatDateDisplay(dateRange.to) }}
                     </span>
                     <span v-else> {{ t("FTTimeframeSelector.selectDateRange") }} </span>
@@ -67,14 +67,14 @@
                 :options="dateOptions"
                 @range-start="handleRangeStart"
                 @range-end="handleRangeEnd"
-                aria-label="Custom date range picker"
+                :aria-label="t('FTTimeframeSelector.customDateRangePickerAriaLabel')"
             >
                 <div class="row items-center justify-end q-gutter-sm">
                     <FTBtn
                         padding="sm"
                         icon="fa fa-trash"
                         color="negative"
-                        aria-label="Clear custom date range"
+                        :aria-label="t('FTTimeframeSelector.clearCustomDateRangeAriaLabel')"
                         @click="clearDateRange"
                         :disabled="!dateRange.from && !dateRange.to"
                     />
@@ -84,12 +84,12 @@
                         :label="t('FTTimeframeSelector.cancel')"
                         color="secondary"
                         @click="closeDateRangePicker"
-                        aria-label="Cancel custom date range"
+                        :aria-label="t('FTTimeframeSelector.cancelCustomDateRangeAriaLabel')"
                     />
                     <FTBtn
                         padding="sm"
                         :label="t('FTTimeframeSelector.apply')"
-                        aria-label="Apply custom date range"
+                        :aria-label="t('FTTimeframeSelector.applyCustomDateRangeAriaLabel')"
                         color="primary"
                         @click="applyDateRange"
                         :disabled="!isValidDateRange"

--- a/packages/frontend/src/components/FTTimezoneList.vue
+++ b/packages/frontend/src/components/FTTimezoneList.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { timezones } from "src/helpers/date-utils";
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 
+const { t } = useI18n();
 const searchQuery = ref("");
 const emit = defineEmits<(event: "timezoneSelected", timezone: string) => void>();
 
@@ -21,13 +23,13 @@ function getFilteredTimezones(): string[] {
     <div class="timezone-selector">
         <q-input
             v-model="searchQuery"
-            placeholder="Search timezones..."
+            :placeholder="t('FTTimezoneList.searchTimezonesPlaceholder')"
             rounded
             standout
             dense
             class="q-mb-md"
             :debounce="300"
-            aria-label="Search timezones"
+            :aria-label="t('FTTimezoneList.searchTimezonesAriaLabel')"
         >
             <template #prepend>
                 <q-icon name="fa fa-search" />

--- a/packages/frontend/src/components/Floor/AddNewFloorForm.vue
+++ b/packages/frontend/src/components/Floor/AddNewFloorForm.vue
@@ -13,7 +13,7 @@ const emit = defineEmits(["create"]);
 const floorName = ref("");
 
 function noSameFloorName(val: string): boolean | string {
-    return !props.allFloorNames.has(val) || "Floor with the same name already exists!";
+    return !props.allFloorNames.has(val) || t('AddNewFloorForm.floorNameExistsError');
 }
 
 function onReset(): void {
@@ -31,7 +31,7 @@ function onSubmit(): void {
             v-model="floorName"
             standout
             rounded
-            label="Floor name *"
+            :label="t('AddNewFloorForm.floorNameLabel')"
             lazy-rules
             :rules="[noEmptyString(), noSameFloorName]"
         />

--- a/packages/frontend/src/components/NetworkOverlay.vue
+++ b/packages/frontend/src/components/NetworkOverlay.vue
@@ -3,12 +3,12 @@
         <q-card class="flex flex-center column justify-center" style="height: 100%">
             <div class="text-h6 q-mb-md">
                 <FTCenteredText>
-                    <q-spinner color="primary" /> No Internet Connection
+                    <q-spinner color="primary" /> {{ t('NetworkOverlay.noInternetConnectionText') }}
                 </FTCenteredText>
             </div>
-            <p class="text-subtitle1">Wait or try to reload the page</p>
+            <p class="text-subtitle1">{{ t('NetworkOverlay.waitOrReloadText') }}</p>
             <p>
-                <q-btn rounded class="button-gradient" @click="refreshApp">Reload</q-btn>
+                <q-btn rounded class="button-gradient" @click="refreshApp">{{ t('NetworkOverlay.reloadButtonLabel') }}</q-btn>
             </p>
         </q-card>
     </q-dialog>
@@ -18,6 +18,8 @@
 import FTCenteredText from "src/components/FTCenteredText.vue";
 import { useNetworkStatus } from "src/composables/useNetworkStatus";
 import { refreshApp } from "src/helpers/utils";
+import { useI18n } from "vue-i18n";
 
 const { isOnline } = useNetworkStatus();
+const { t } = useI18n();
 </script>

--- a/packages/frontend/src/components/TelNumberInput/TelNumberInput.vue
+++ b/packages/frontend/src/components/TelNumberInput/TelNumberInput.vue
@@ -13,7 +13,7 @@
                 @filter="onFilterCountries"
                 clearable
                 clear-icon="fa fa-close"
-                clear-icon-label="Clear"
+                :clear-icon-label="t('TelNumberInput.clearButtonLabel')"
                 :rules="[validateCountrySelection]"
             >
                 <template #option="scope">
@@ -164,10 +164,10 @@ function validateCountrySelection(): boolean | string {
 
     if (required) {
         if (!country) {
-            return "Please select a country code";
+            return t('TelNumberInput.selectCountryCodeValidationMsg');
         }
     } else if (number && !country) {
-        return "Please select a country code";
+        return t('TelNumberInput.selectCountryCodeValidationMsg');
     }
     return true;
 }
@@ -178,7 +178,7 @@ function validatePhoneNumber(): boolean | string {
 
     if (required) {
         if (!country || !number) {
-            return "Please provide both country code and phone number";
+            return t('TelNumberInput.provideCountryAndNumberValidationMsg');
         }
     } else {
         if (!country && !number) {
@@ -186,17 +186,17 @@ function validatePhoneNumber(): boolean | string {
             return true;
         }
         if ((country && !number) || (!country && number)) {
-            return "Please provide both country code and phone number";
+            return t('TelNumberInput.provideCountryAndNumberValidationMsg');
         }
     }
 
     if (!country) {
-        return "Please select a country code";
+        return t('TelNumberInput.selectCountryCodeValidationMsg');
     }
 
     const phoneNumberObj = parsePhoneNumberFromString(fullNumber.value);
     if (!phoneNumberObj?.isValid()) {
-        return "Invalid phone number";
+        return t('TelNumberInput.invalidPhoneNumberValidationMsg');
     }
 
     return true;

--- a/packages/frontend/src/components/admin/analytics/PieChart.vue
+++ b/packages/frontend/src/components/admin/analytics/PieChart.vue
@@ -7,6 +7,7 @@ import { use } from "echarts/core";
 import { CanvasRenderer } from "echarts/renderers";
 import { isDark } from "src/global-reactives/is-dark";
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import VChart from "vue-echarts";
 
 // Register ECharts components
@@ -17,6 +18,7 @@ const props = defineProps<{
     chartTitle: string;
 }>();
 
+const { t } = useI18n();
 const backgroundColor = computed(() => (isDark.value ? "#1A1A1A" : "#FFFFFF"));
 const textColor = computed(() => (isDark.value ? "#cccccc" : "#1A1A1A"));
 
@@ -71,7 +73,7 @@ const chartOption = computed<ECPieOption>(() => ({
         borderWidth: 1,
         formatter(params: any) {
             const { name, percent, value } = params;
-            return `${name}<br/>Value: ${value}<br/>Percentage: ${percent}%`;
+            return `${name}<br/>${t('PieChart.tooltipValue')}: ${value}<br/>${t('PieChart.tooltipPercentage')}: ${percent}%`;
         },
         textStyle: {
             color: "#1A1A1A",

--- a/packages/frontend/src/components/admin/drink-cards/DrinkBundleDialog.vue
+++ b/packages/frontend/src/components/admin/drink-cards/DrinkBundleDialog.vue
@@ -102,12 +102,12 @@ function getItemName(itemId: string): string {
     const item = props.availableItems.find(function ({ inventoryItemId }) {
         return inventoryItemId === itemId;
     });
-    return item?.name ?? "Unknown Item";
+    return item?.name ?? t('DrinkBundleDialog.unknownItemText');
 }
 
 function handleBundleSubmit(): void {
     if (!bundle.value.name || bundle.value.items.length === 0) {
-        showErrorMessage("Please fill in all required fields");
+        showErrorMessage(t('DrinkBundleDialog.fillRequiredFieldsError'));
         return;
     }
 
@@ -174,7 +174,7 @@ function openItemSelectionDialog(index: number): void {
 }
 
 async function removeBundleItem(index: number): Promise<void> {
-    const confirmed = await showConfirm("Are you sure you want to remove this item?");
+    const confirmed = await showConfirm(t('DrinkBundleDialog.removeItemConfirmMsg'));
 
     if (!confirmed) return;
 
@@ -187,33 +187,33 @@ async function removeBundleItem(index: number): Promise<void> {
         <q-card-section class="q-gutter-y-md">
             <q-input
                 v-model="bundle.name"
-                label="Bundle Name"
-                :rules="[noEmptyString('Name is required')]"
+                :label="t('DrinkBundleDialog.bundleNameLabel')"
+                :rules="[noEmptyString(t('DrinkBundleDialog.nameIsRequiredError'))]"
                 standout
                 rounded
             />
 
             <q-input
                 v-model="bundle.description"
-                label="Description (Optional)"
+                :label="t('DrinkBundleDialog.descriptionOptionalLabel')"
                 type="textarea"
                 standout
                 rounded
             />
 
             <!-- Item Selection -->
-            <div class="text-subtitle2 q-mb-sm">Bundle Items</div>
+            <div class="text-subtitle2 q-mb-sm">{{ t('DrinkBundleDialog.bundleItemsLabel', { count: bundle.items.length }) }}</div>
             <div v-for="(item, index) in bundle.items" :key="index" class="q-mb-md">
                 <div class="row q-col-gutter-sm items-center">
                     <div class="col">
                         <q-input
-                            :label="'Select Drink'"
+                            :label="t('DrinkBundleDialog.selectDrinkLabel')"
                             :model-value="getItemName(item.inventoryItemId)"
                             readonly
                             @click="openItemSelectionDialog(index)"
                             standout
                             rounded
-                            :rules="[noEmptyString('Please select a drink')]"
+                            :rules="[noEmptyString(t('DrinkBundleDialog.pleaseSelectDrinkError'))]"
                             class="cursor-pointer"
                         />
                     </div>
@@ -221,10 +221,10 @@ async function removeBundleItem(index: number): Promise<void> {
                         <q-input
                             v-model.number="item.quantity"
                             type="number"
-                            label="Qty"
+                            :label="t('DrinkBundleDialog.qtyLabel')"
                             standout
                             rounded
-                            :rules="[greaterThanZero('Quantity must be greater than 0')]"
+                            :rules="[greaterThanZero(t('DrinkBundleDialog.quantityGreaterThanZeroError'))]"
                         />
                     </div>
                     <div class="col-auto">
@@ -250,34 +250,34 @@ async function removeBundleItem(index: number): Promise<void> {
                     <q-input
                         v-model.number="bundle.price"
                         type="number"
-                        label="Bundle Price"
+                        :label="t('DrinkBundleDialog.bundlePriceLabel')"
                         prefix="€"
                         standout
                         rounded
                         :rules="[
-                            greaterThanZero('Price is required and must be greater than 0'),
+                            greaterThanZero(t('DrinkBundleDialog.priceGreaterThanZeroError')),
                             numberInRange(
                                 0,
                                 calculateRegularPrice(bundle.items),
-                                'Bundle price should be lower than regular price',
+                                t('DrinkBundleDialog.bundlePriceLowerThanRegularError'),
                             ),
                         ]"
                     />
                 </div>
                 <div class="col-auto">
                     <div class="text-positive" v-if="bundle.price > 0">
-                        Save {{ calculateSavings(bundle) }}%
+                        {{ t('DrinkBundleDialog.savePercentageText', { percentage: calculateSavings(bundle) }) }}
                     </div>
                 </div>
             </div>
         </q-card-section>
 
         <q-card-actions align="right">
-            <q-btn flat label="Cancel" @click="closeDialog" />
+            <q-btn flat :label="t('DrinkBundleDialog.cancelButtonLabel')" @click="closeDialog" />
             <q-btn
                 rounded
                 class="button-gradient"
-                :label="isEditMode ? t('Global.submit') : 'Create Bundle'"
+                :label="isEditMode ? t('Global.submit') : t('DrinkBundleDialog.createBundleButtonLabel')"
                 @click="handleBundleSubmit"
             />
         </q-card-actions>

--- a/packages/frontend/src/components/admin/drink-cards/DrinkCardBuilderAddDragElementsDropdown.vue
+++ b/packages/frontend/src/components/admin/drink-cards/DrinkCardBuilderAddDragElementsDropdown.vue
@@ -42,7 +42,7 @@ function showBundleDialog(bundleToEdit?: DrinkBundle): void {
                     dialog.hide();
                 },
             },
-            title: bundleToEdit ? "Edit Bundle" : "Create Bundle",
+            title: bundleToEdit ? t('DrinkCardBuilderAddDragElementsDropdown.editBundleDialogTitle') : t('DrinkCardBuilderAddDragElementsDropdown.createBundleDialogTitle'),
         },
     });
 }
@@ -70,15 +70,15 @@ defineExpose({ showBundleDialog });
     <q-btn-dropdown flat rounded color="primary" icon="fa fa-plus" class="button-gradient">
         <q-list>
             <q-item clickable v-close-popup @click="$emit('add-header')">
-                <q-item-section>Add Header</q-item-section>
+                <q-item-section>{{ t('DrinkCardBuilderAddDragElementsDropdown.addHeaderLabel') }}</q-item-section>
             </q-item>
 
             <q-item clickable v-close-popup @click="$emit('add-header-end')">
-                <q-item-section>Add Header End</q-item-section>
+                <q-item-section>{{ t('DrinkCardBuilderAddDragElementsDropdown.addHeaderEndLabel') }}</q-item-section>
             </q-item>
 
             <q-item clickable v-close-popup @click="showBundleDialog()">
-                <q-item-section>Add Bundle</q-item-section>
+                <q-item-section>{{ t('DrinkCardBuilderAddDragElementsDropdown.addBundleLabel') }}</q-item-section>
             </q-item>
 
             <q-item clickable v-close-popup @click="showCustomSectionDialog">

--- a/packages/frontend/src/components/admin/drink-cards/DrinkCardBuilderCustomSectionDialog.vue
+++ b/packages/frontend/src/components/admin/drink-cards/DrinkCardBuilderCustomSectionDialog.vue
@@ -43,7 +43,7 @@ function handleCustomSectionSubmit(): void {
                 :label="t('PageAdminPropertyDrinkCards.sectionNameLabel')"
                 standout
                 rounded
-                :rules="[noEmptyString('Name is required')]"
+                :rules="[noEmptyString(t('DrinkCardBuilderCustomSectionDialog.nameIsRequiredError'))]"
             />
 
             <div class="text-caption">

--- a/packages/frontend/src/components/admin/drink-cards/DrinkCardBuilderItemSelectionDialog.vue
+++ b/packages/frontend/src/components/admin/drink-cards/DrinkCardBuilderItemSelectionDialog.vue
@@ -4,6 +4,7 @@ import type { DrinkCardItem, InventoryItemDoc } from "@firetable/types";
 import { uniq } from "es-toolkit";
 import { property } from "es-toolkit/compat";
 import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
 
 interface Emits {
     (event: "update:modelValue", value: boolean): void;
@@ -83,7 +84,7 @@ function toggleCategory(category: string): void {
             standout
             rounded
             debounce="300"
-            placeholder="Search items"
+            :placeholder="t('DrinkCardBuilderItemSelectionDialog.searchItemsPlaceholder')"
             class="q-mb-md"
         >
             <template #prepend>
@@ -105,7 +106,7 @@ function toggleCategory(category: string): void {
             </q-item>
 
             <q-item v-if="filteredItems.length === 0">
-                <q-item-section class="text-center text-grey"> No items found </q-item-section>
+                <q-item-section class="text-center text-grey"> {{ t('DrinkCardBuilderItemSelectionDialog.noItemsFoundText') }} </q-item-section>
             </q-item>
         </q-list>
     </q-card-section>

--- a/packages/frontend/src/i18n/de/index.ts
+++ b/packages/frontend/src/i18n/de/index.ts
@@ -1,6 +1,10 @@
 import type { TranslationStructure } from "src/i18n/en-GB";
 
 const de: TranslationStructure = {
+    AddNewFloorForm: {
+        floorNameLabel: "Etagenname *",
+        floorNameExistsError: "Etage mit diesem Namen existiert bereits!",
+    },
     AddNewGuestForm: {
         guestNameInputLabel: "Gastname *",
     },
@@ -10,6 +14,13 @@ const de: TranslationStructure = {
     },
     AppDrawer: {
         languageSelectorLabel: "Sprache",
+        logoutAriaLabel: "Abmelden",
+        languages: {
+            english: "Englisch",
+            german: "Deutsch",
+            spanish: "Spanisch",
+            croatian: "Kroatisch",
+        },
         links: {
             issueReportsOverview: "Fehlerberichte",
             logout: "Abmelden",
@@ -28,6 +39,9 @@ const de: TranslationStructure = {
             darkMode: "Dunkelmodus umschalten",
             onlineStatus: "Online-Status umschalten",
         },
+    },
+    AppTopMenu: {
+        menuAriaLabel: "Menü",
     },
     EventCard: {
         freeLabel: "Kostenlos",
@@ -71,6 +85,10 @@ const de: TranslationStructure = {
     },
     EventGuestSearch: {
         label: "Tische nach Gastnamen durchsuchen...",
+        hideArrivedLabel: "Angekommene ausblenden",
+        guestArrivedIconAriaLabel: "Symbol für angekommenen Gast",
+        noResultsText: "Keine Ergebnisse",
+        onFloorConnector: "auf",
     },
     EventInfo: {
         eventInfoEmptyMsg: "Es gibt keine Informationen zu dieser Veranstaltung.",
@@ -102,6 +120,12 @@ const de: TranslationStructure = {
         unlinkTablesLabel: "Tischverbindung aufheben",
         waitingForResponse: "Warte auf Rückmeldung",
     },
+    FTBottomDialog: {
+        closeBottomDialogAriaLabel: "Unteren Dialog schließen",
+    },
+    FTDialog: {
+        closeDialogAriaLabel: "Dialog schließen",
+    },
     FTTimeframeSelector: {
         apply: "Anwenden",
         cancel: "Abbrechen",
@@ -117,6 +141,62 @@ const de: TranslationStructure = {
         selectTimeframe: "Zeitraum auswählen",
         today: "Heute",
         yesterday: "Gestern",
+        to: "bis",
+        customDateRangePickerAriaLabel: "Benutzerdefinierter Datumsbereichswähler",
+        clearCustomDateRangeAriaLabel: "Benutzerdefinierten Datumsbereich löschen",
+        cancelCustomDateRangeAriaLabel: "Benutzerdefinierten Datumsbereich abbrechen",
+        applyCustomDateRangeAriaLabel: "Benutzerdefinierten Datumsbereich anwenden",
+    },
+    FTTimezoneList: {
+        searchTimezonesPlaceholder: "Zeitzonen suchen...",
+        searchTimezonesAriaLabel: "Zeitzonen suchen",
+    },
+    NetworkOverlay: {
+        noInternetConnectionText: "Keine Internetverbindung",
+        waitOrReloadText: "Warten Sie oder versuchen Sie, die Seite neu zu laden",
+        reloadButtonLabel: "Neu laden",
+    },
+    TelNumberInput: {
+        clearButtonLabel: "Löschen",
+        selectCountryCodeValidationMsg: "Bitte wählen Sie eine Landesvorwahl",
+        provideCountryAndNumberValidationMsg: "Bitte geben Sie sowohl Landesvorwahl als auch Telefonnummer an",
+        invalidPhoneNumberValidationMsg: "Ungültige Telefonnummer",
+    },
+    PieChart: {
+        tooltipValue: "Wert",
+        tooltipPercentage: "Prozentsatz",
+    },
+    DrinkBundleDialog: {
+        bundleNameLabel: "Paketname",
+        descriptionOptionalLabel: "Beschreibung (Optional)",
+        selectDrinkLabel: "Getränk auswählen",
+        qtyLabel: "Menge",
+        bundlePriceLabel: "Paketpreis",
+        nameIsRequiredError: "Name ist erforderlich",
+        pleaseSelectDrinkError: "Bitte wählen Sie ein Getränk aus",
+        quantityGreaterThanZeroError: "Menge muss größer als 0 sein",
+        priceGreaterThanZeroError: "Preis ist erforderlich und muss größer als 0 sein",
+        bundlePriceLowerThanRegularError: "Paketpreis sollte niedriger als der reguläre Preis sein",
+        fillRequiredFieldsError: "Bitte füllen Sie alle Pflichtfelder aus",
+        savePercentageText: "{percentage}% sparen",
+        createBundleButtonLabel: "Paket erstellen",
+        removeItemConfirmMsg: "Möchten Sie diesen Artikel wirklich entfernen?",
+        unknownItemText: "Unbekannter Artikel",
+        cancelButtonLabel: "Abbrechen",
+    },
+    DrinkCardBuilderAddDragElementsDropdown: {
+        addHeaderLabel: "Kopfzeile hinzufügen",
+        addHeaderEndLabel: "Kopfzeilenende hinzufügen",
+        addBundleLabel: "Paket hinzufügen",
+        editBundleDialogTitle: "Paket bearbeiten",
+        createBundleDialogTitle: "Paket erstellen",
+    },
+    DrinkCardBuilderCustomSectionDialog: {
+        nameIsRequiredError: "Name ist erforderlich",
+    },
+    DrinkCardBuilderItemSelectionDialog: {
+        searchItemsPlaceholder: "Artikel suchen",
+        noItemsFoundText: "Keine Artikel gefunden",
     },
     Global: {
         actions: "Aktionen",

--- a/packages/frontend/src/i18n/en-GB/index.ts
+++ b/packages/frontend/src/i18n/en-GB/index.ts
@@ -1,4 +1,8 @@
 const enGB = {
+    AddNewFloorForm: {
+        floorNameLabel: "Floor name *",
+        floorNameExistsError: "Floor with the same name already exists!",
+    },
     AddNewGuestForm: {
         guestNameInputLabel: "Guest name *",
     },
@@ -8,6 +12,13 @@ const enGB = {
     },
     AppDrawer: {
         languageSelectorLabel: "Language",
+        logoutAriaLabel: "Logout",
+        languages: {
+            english: "English",
+            german: "German",
+            spanish: "Spanish",
+            croatian: "Croatian",
+        },
         links: {
             issueReportsOverview: "Issue Reports Overview",
             logout: "Logout",
@@ -26,6 +37,9 @@ const enGB = {
             darkMode: "Toggle dark mode",
             onlineStatus: "Toggle online status",
         },
+    },
+    AppTopMenu: {
+        menuAriaLabel: "Menu",
     },
     EventCard: {
         freeLabel: "Free",
@@ -68,6 +82,10 @@ const enGB = {
     },
     EventGuestSearch: {
         label: "Search tables by guest name...",
+        hideArrivedLabel: "Hide arrived",
+        guestArrivedIconAriaLabel: "Guest arrived checkmark icon",
+        noResultsText: "No results",
+        onFloorConnector: "on",
     },
     EventInfo: {
         eventInfoEmptyMsg: "There is no event description set for this event!",
@@ -99,6 +117,12 @@ const enGB = {
         unlinkTablesLabel: "Unlink tables",
         waitingForResponse: "Waiting for response",
     },
+    FTBottomDialog: {
+        closeBottomDialogAriaLabel: "Close bottom dialog",
+    },
+    FTDialog: {
+        closeDialogAriaLabel: "Close dialog",
+    },
     FTTimeframeSelector: {
         apply: "Apply",
         cancel: "Cancel",
@@ -114,6 +138,62 @@ const enGB = {
         selectTimeframe: "Select Timeframe",
         today: "Today",
         yesterday: "Yesterday",
+        to: "to",
+        customDateRangePickerAriaLabel: "Custom date range picker",
+        clearCustomDateRangeAriaLabel: "Clear custom date range",
+        cancelCustomDateRangeAriaLabel: "Cancel custom date range",
+        applyCustomDateRangeAriaLabel: "Apply custom date range",
+    },
+    FTTimezoneList: {
+        searchTimezonesPlaceholder: "Search timezones...",
+        searchTimezonesAriaLabel: "Search timezones",
+    },
+    NetworkOverlay: {
+        noInternetConnectionText: "No Internet Connection",
+        waitOrReloadText: "Wait or try to reload the page",
+        reloadButtonLabel: "Reload",
+    },
+    TelNumberInput: {
+        clearButtonLabel: "Clear",
+        selectCountryCodeValidationMsg: "Please select a country code",
+        provideCountryAndNumberValidationMsg: "Please provide both country code and phone number",
+        invalidPhoneNumberValidationMsg: "Invalid phone number",
+    },
+    PieChart: {
+        tooltipValue: "Value",
+        tooltipPercentage: "Percentage",
+    },
+    DrinkBundleDialog: {
+        bundleNameLabel: "Bundle Name",
+        descriptionOptionalLabel: "Description (Optional)",
+        selectDrinkLabel: "Select Drink",
+        qtyLabel: "Qty",
+        bundlePriceLabel: "Bundle Price",
+        nameIsRequiredError: "Name is required",
+        pleaseSelectDrinkError: "Please select a drink",
+        quantityGreaterThanZeroError: "Quantity must be greater than 0",
+        priceGreaterThanZeroError: "Price is required and must be greater than 0",
+        bundlePriceLowerThanRegularError: "Bundle price should be lower than regular price",
+        fillRequiredFieldsError: "Please fill in all required fields",
+        savePercentageText: "Save {percentage}%",
+        createBundleButtonLabel: "Create Bundle",
+        removeItemConfirmMsg: "Are you sure you want to remove this item?",
+        unknownItemText: "Unknown Item", // Though likely not used if items are always found
+        cancelButtonLabel: "Cancel",
+    },
+    DrinkCardBuilderAddDragElementsDropdown: {
+        addHeaderLabel: "Add Header",
+        addHeaderEndLabel: "Add Header End",
+        addBundleLabel: "Add Bundle",
+        editBundleDialogTitle: "Edit Bundle",
+        createBundleDialogTitle: "Create Bundle",
+    },
+    DrinkCardBuilderCustomSectionDialog: {
+        nameIsRequiredError: "Name is required",
+    },
+    DrinkCardBuilderItemSelectionDialog: {
+        searchItemsPlaceholder: "Search items",
+        noItemsFoundText: "No items found",
     },
     Global: {
         actions: "Actions",

--- a/packages/frontend/src/i18n/es/index.ts
+++ b/packages/frontend/src/i18n/es/index.ts
@@ -1,6 +1,10 @@
 import type { TranslationStructure } from "src/i18n/en-GB";
 
 const es: TranslationStructure = {
+    AddNewFloorForm: {
+        floorNameLabel: "Nombre del piso *",
+        floorNameExistsError: "¡Ya existe un piso con el mismo nombre!",
+    },
     AddNewGuestForm: {
         guestNameInputLabel: "Nombre de invitado *",
     },
@@ -11,6 +15,13 @@ const es: TranslationStructure = {
     },
     AppDrawer: {
         languageSelectorLabel: "Lenguaje",
+        logoutAriaLabel: "Cerrar sesión",
+        languages: {
+            english: "Inglés",
+            german: "Alemán",
+            spanish: "Español",
+            croatian: "Croata",
+        },
         links: {
             issueReportsOverview: "Reportes de Problemas",
             logout: "Cerrar sesión",
@@ -29,6 +40,9 @@ const es: TranslationStructure = {
             darkMode: "Modo oscuro",
             onlineStatus: "Estado en línea",
         },
+    },
+    AppTopMenu: {
+        menuAriaLabel: "Menú",
     },
     EventCard: {
         freeLabel: "Gratis",
@@ -71,6 +85,10 @@ const es: TranslationStructure = {
     },
     EventGuestSearch: {
         label: "Buscar mesas por nombre de invitado...",
+        hideArrivedLabel: "Ocultar llegados",
+        guestArrivedIconAriaLabel: "Icono de marca de llegada de invitado",
+        noResultsText: "No hay resultados",
+        onFloorConnector: "en",
     },
     EventInfo: {
         eventInfoEmptyMsg: "¡No hay descripción del evento!",
@@ -102,6 +120,12 @@ const es: TranslationStructure = {
         unlinkTablesLabel: "Desvincular mesas",
         waitingForResponse: "Esperando respuesta",
     },
+    FTBottomDialog: {
+        closeBottomDialogAriaLabel: "Cerrar diálogo inferior",
+    },
+    FTDialog: {
+        closeDialogAriaLabel: "Cerrar diálogo",
+    },
     FTTimeframeSelector: {
         apply: "Aplicar",
         cancel: "Cancelar",
@@ -117,6 +141,62 @@ const es: TranslationStructure = {
         selectTimeframe: "Seleccionar rango de tiempo",
         today: "Hoy",
         yesterday: "Ayer",
+        to: "a",
+        customDateRangePickerAriaLabel: "Selector de rango de fechas personalizado",
+        clearCustomDateRangeAriaLabel: "Borrar rango de fechas personalizado",
+        cancelCustomDateRangeAriaLabel: "Cancelar rango de fechas personalizado",
+        applyCustomDateRangeAriaLabel: "Aplicar rango de fechas personalizado",
+    },
+    FTTimezoneList: {
+        searchTimezonesPlaceholder: "Buscar zonas horarias...",
+        searchTimezonesAriaLabel: "Buscar zonas horarias",
+    },
+    NetworkOverlay: {
+        noInternetConnectionText: "Sin conexión a Internet",
+        waitOrReloadText: "Espere o intente recargar la página",
+        reloadButtonLabel: "Recargar",
+    },
+    TelNumberInput: {
+        clearButtonLabel: "Borrar",
+        selectCountryCodeValidationMsg: "Por favor seleccione un código de país",
+        provideCountryAndNumberValidationMsg: "Por favor proporcione el código de país y el número de teléfono",
+        invalidPhoneNumberValidationMsg: "Número de teléfono inválido",
+    },
+    PieChart: {
+        tooltipValue: "Valor",
+        tooltipPercentage: "Porcentaje",
+    },
+    DrinkBundleDialog: {
+        bundleNameLabel: "Nombre del Paquete",
+        descriptionOptionalLabel: "Descripción (Opcional)",
+        selectDrinkLabel: "Seleccionar Bebida",
+        qtyLabel: "Cant.",
+        bundlePriceLabel: "Precio del Paquete",
+        nameIsRequiredError: "El nombre es obligatorio",
+        pleaseSelectDrinkError: "Por favor seleccione una bebida",
+        quantityGreaterThanZeroError: "La cantidad debe ser mayor que 0",
+        priceGreaterThanZeroError: "El precio es obligatorio y debe ser mayor que 0",
+        bundlePriceLowerThanRegularError: "El precio del paquete debe ser inferior al precio regular",
+        fillRequiredFieldsError: "Por favor complete todos los campos obligatorios",
+        savePercentageText: "Ahorrar {percentage}%",
+        createBundleButtonLabel: "Crear Paquete",
+        removeItemConfirmMsg: "¿Está seguro de que desea eliminar este artículo?",
+        unknownItemText: "Artículo Desconocido",
+        cancelButtonLabel: "Cancelar",
+    },
+    DrinkCardBuilderAddDragElementsDropdown: {
+        addHeaderLabel: "Añadir Encabezado",
+        addHeaderEndLabel: "Añadir Fin de Encabezado",
+        addBundleLabel: "Añadir Paquete",
+        editBundleDialogTitle: "Editar Paquete",
+        createBundleDialogTitle: "Crear Paquete",
+    },
+    DrinkCardBuilderCustomSectionDialog: {
+        nameIsRequiredError: "El nombre es obligatorio",
+    },
+    DrinkCardBuilderItemSelectionDialog: {
+        searchItemsPlaceholder: "Buscar artículos",
+        noItemsFoundText: "No se encontraron artículos",
     },
     Global: {
         actions: "Acciones",

--- a/packages/frontend/src/i18n/hr/index.ts
+++ b/packages/frontend/src/i18n/hr/index.ts
@@ -1,6 +1,10 @@
 import type { TranslationStructure } from "src/i18n/en-GB";
 
 const hr: TranslationStructure = {
+    AddNewFloorForm: {
+        floorNameLabel: "Naziv kata *",
+        floorNameExistsError: "Kat s istim nazivom već postoji!",
+    },
     AddNewGuestForm: {
         guestNameInputLabel: "Ime gosta *",
     },
@@ -10,6 +14,13 @@ const hr: TranslationStructure = {
     },
     AppDrawer: {
         languageSelectorLabel: "Jezik",
+        logoutAriaLabel: "Odjavi se",
+        languages: {
+            english: "Engleski",
+            german: "Njemački",
+            spanish: "Španjolski",
+            croatian: "Hrvatski",
+        },
         links: {
             issueReportsOverview: "Pregled prijava problema",
             logout: "Odjava",
@@ -28,6 +39,9 @@ const hr: TranslationStructure = {
             darkMode: "Prebaci na tamni način",
             onlineStatus: "Prebaci status online",
         },
+    },
+    AppTopMenu: {
+        menuAriaLabel: "Izbornik",
     },
     EventCard: {
         freeLabel: "Besplatno",
@@ -70,6 +84,10 @@ const hr: TranslationStructure = {
     },
     EventGuestSearch: {
         label: "Pretraži stolove po imenu gosta...",
+        hideArrivedLabel: "Sakrij pristigle",
+        guestArrivedIconAriaLabel: "Ikona oznake dolaska gosta",
+        noResultsText: "Nema rezultata",
+        onFloorConnector: "na",
     },
     EventInfo: {
         eventInfoEmptyMsg: "Nema opisa događaja za ovaj događaj!",
@@ -101,6 +119,12 @@ const hr: TranslationStructure = {
         unlinkTablesLabel: "Odvoji stolove",
         waitingForResponse: "Čekanje na odgovor",
     },
+    FTBottomDialog: {
+        closeBottomDialogAriaLabel: "Zatvori donji dijalog",
+    },
+    FTDialog: {
+        closeDialogAriaLabel: "Zatvori dijalog",
+    },
     FTTimeframeSelector: {
         apply: "Primijeni",
         cancel: "Otkaži",
@@ -116,6 +140,62 @@ const hr: TranslationStructure = {
         selectTimeframe: "Odaberite vremenski okvir",
         today: "Danas",
         yesterday: "Jučer",
+        to: "do",
+        customDateRangePickerAriaLabel: "Prilagođeni birač raspona datuma",
+        clearCustomDateRangeAriaLabel: "Očisti prilagođeni raspon datuma",
+        cancelCustomDateRangeAriaLabel: "Otkaži prilagođeni raspon datuma",
+        applyCustomDateRangeAriaLabel: "Primijeni prilagođeni raspon datuma",
+    },
+    FTTimezoneList: {
+        searchTimezonesPlaceholder: "Pretraži vremenske zone...",
+        searchTimezonesAriaLabel: "Pretraži vremenske zone",
+    },
+    NetworkOverlay: {
+        noInternetConnectionText: "Nema internetske veze",
+        waitOrReloadText: "Pričekajte ili pokušajte ponovno učitati stranicu",
+        reloadButtonLabel: "Ponovno učitaj",
+    },
+    TelNumberInput: {
+        clearButtonLabel: "Očisti",
+        selectCountryCodeValidationMsg: "Molimo odaberite pozivni broj zemlje",
+        provideCountryAndNumberValidationMsg: "Molimo unesite i pozivni broj zemlje i broj telefona",
+        invalidPhoneNumberValidationMsg: "Nevažeći telefonski broj",
+    },
+    PieChart: {
+        tooltipValue: "Vrijednost",
+        tooltipPercentage: "Postotak",
+    },
+    DrinkBundleDialog: {
+        bundleNameLabel: "Naziv Paketa",
+        descriptionOptionalLabel: "Opis (Neobavezno)",
+        selectDrinkLabel: "Odaberi Piće",
+        qtyLabel: "Kol.",
+        bundlePriceLabel: "Cijena Paketa",
+        nameIsRequiredError: "Naziv je obavezan",
+        pleaseSelectDrinkError: "Molimo odaberite piće",
+        quantityGreaterThanZeroError: "Količina mora biti veća od 0",
+        priceGreaterThanZeroError: "Cijena je obavezna i mora biti veća od 0",
+        bundlePriceLowerThanRegularError: "Cijena paketa treba biti niža od redovne cijene",
+        fillRequiredFieldsError: "Molimo ispunite sva obavezna polja",
+        savePercentageText: "Uštedi {percentage}%",
+        createBundleButtonLabel: "Kreiraj Paket",
+        removeItemConfirmMsg: "Jeste li sigurni da želite ukloniti ovu stavku?",
+        unknownItemText: "Nepoznata Stavka",
+        cancelButtonLabel: "Odustani",
+    },
+    DrinkCardBuilderAddDragElementsDropdown: {
+        addHeaderLabel: "Dodaj Zaglavlje",
+        addHeaderEndLabel: "Dodaj Kraj Zaglavlja",
+        addBundleLabel: "Dodaj Paket",
+        editBundleDialogTitle: "Uredi Paket",
+        createBundleDialogTitle: "Kreiraj Paket",
+    },
+    DrinkCardBuilderCustomSectionDialog: {
+        nameIsRequiredError: "Naziv je obavezan",
+    },
+    DrinkCardBuilderItemSelectionDialog: {
+        searchItemsPlaceholder: "Pretraži stavke",
+        noItemsFoundText: "Nema pronađenih stavki",
     },
     Global: {
         actions: "Radnje",


### PR DESCRIPTION
This commit introduces internationalization for multiple Vue components by adding new translation keys and updating the components to use them. Approximate translations have been provided for German, Spanish, and Croatian, alongside English.

Affected components and key additions include:

- AppDrawer.vue: Logout aria-label, language names.
- AppTopMenu.vue: Menu aria-label.
- EventGuestSearch.vue: Checkbox label, icon aria-label, no results text, 'on' connector.
- FTBottomDialog.vue: Close dialog aria-label.
- FTDialog.vue: Close dialog aria-label.
- FTTimeframeSelector.vue: 'to' connector, date picker aria-labels.
- FTTimezoneList.vue: Search placeholder and aria-label.
- Floor/AddNewFloorForm.vue: Label and validation error.
- NetworkOverlay.vue: Connection status texts and button label.
- TelNumberInput/TelNumberInput.vue: Clear button label, validation messages.
- admin/analytics/PieChart.vue: Tooltip formatter texts.
- admin/drink-cards/DrinkBundleDialog.vue: Various labels, validation messages, button texts, fallbacks, and confirmation messages.
- admin/drink-cards/DrinkCardBuilderAddDragElementsDropdown.vue: Menu item texts and dialog titles.
- admin/drink-cards/DrinkCardBuilderCustomSectionDialog.vue: Validation message.
- admin/drink-cards/DrinkCardBuilderItemSelectionDialog.vue: Placeholder and fallback text.

All corresponding i18n files (en-GB, de, es, hr) have been updated with the new keys under their respective component scopes.